### PR TITLE
Change image to opensuse/leap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/archive:latest
+FROM opensuse/leap:latest
 
 # General information
 LABEL de.itsfullofstars.sapnwdocker.version="1.0.0"


### PR DESCRIPTION
The build doesn't work anymore with the `opensuse/archive` image due to errors with the user paths und the bin folder.
Changed the image to `opensuse/leap`.